### PR TITLE
Ignore filter adjusted to include only needed

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,19 +16,9 @@
   ],
   "license": "MIT",
   "ignore": [
-    "**/.*",
-    "node_modules",
-    "bower_components",
-    "test",
-    "_includes",
-    "_layouts",
-    "_posts",
-    "_sass",
-    "_site",
-    "about.md",
-    "css",
-    "_config.yml",
-    "index.html"
+    "*",
+    "!jekyll-search.js",
+    "!README.md"
   ],
   "moduleType": [
     "globals"


### PR DESCRIPTION
No one needs source files and JSON data samples in bower package, there are only two needed files:

- jekyll-search.js
- README.md

That why ignore filter is adjusted accordingly:

1. Exclude all
2. Include needed files back

And package size went down from 25 to 10 KB.